### PR TITLE
Fix to issue: GAP doesn't collect words properly with "-"

### DIFF
--- a/GAP.py
+++ b/GAP.py
@@ -3880,9 +3880,11 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, ITab):
             print("getPathWords started")
         try:
             # Split the URL on /
-            words = re.compile(r"[\:/?=\-&#]+", re.UNICODE).split(path) + path.split('/')
-            # Deduplicate the words list
-            words = list(set(words))
+            words = set(re.compile(r"[\:/?=\-&#]+", re.UNICODE).split(path) + path.split('/'))
+            temp = []
+            for x in words:
+                temp.extend(x.split(","))
+            words = set(temp)
             # Add the word to the parameter list, unless it has a . in it or is a number. or it is a single character that isn't a letter
             for word in words:
                 if (

--- a/GAP.py
+++ b/GAP.py
@@ -3880,7 +3880,9 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, ITab):
             print("getPathWords started")
         try:
             # Split the URL on /
-            words = re.compile(r"[\:/?=\-&#]+", re.UNICODE).split(path)
+            words = re.compile(r"[\:/?=\-&#]+", re.UNICODE).split(path) + path.split('/')
+            # Deduplicate the words list
+            words = list(set(words))
             # Add the word to the parameter list, unless it has a . in it or is a number. or it is a single character that isn't a letter
             for word in words:
                 if (


### PR DESCRIPTION
I've noticed that GAP doesn't collect words properly from URL paths that look like this:
`/api/custom-polls/home/pending-draft-polls-count`

Old version collects only the following words:
`api,custom,pools,home,pending,draft,polls,count`

It should collect the following words:
`api,custom-pools,custom,pools,home,pending-draft-polls-count,pending,draft,count`

I've made a fix for this issue, although it needs further testing.


