### PR TITLE
GAP v4.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 __pycache__
 *.class
+BappModules/

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,17 @@
+<p>This extension helps find potential endpoints, parameters, and generate a custom target wordlist.</p>
+
+<p>Usage</p>
+
+<ul>
+	<li>Select a target in your Burp scope (or multiple targets), or even just one subfolder or endpoint, and use the context menu action to send the target to "GAP". Alternatively, right click a request or response in any other context and select GAP from the Extensions menu.</li>
+	<li>Go to the GAP tab to view the results.</li>
+</ul>
+
+<p>Important notes:</p>
+<ul>
+	<li>If you don't need one of the modes, then un-check it as results will be quicker.</li>
+	<li>If you run GAP for one or more targets from the Site Map view, don't have them expanded when you run GAP... unfortunately this can make it a lot slower. It will be more efficient if you run for one or two target in the Site Map view at a time, as huge projects can have consume a lot of resources.</li>
+	<li>If you want to run GAP on one of more specific requests, do not select them from the Site Map tree view. It will be a lot quicker to run it from the Site Map Contents view if possible, or from proxy history.</li>
+	<li>It is hard to design GAP to display all controls for all screen resolutions and font sizes. I have tried to deal with the most common setups, but if you find you cannot see all the controls, you can hold down the "Ctrl" button and click the GAP logo header image to remove it to make more space.</li>
+	<li>The Words mode uses the "beautifulsoup4" library and this can be quite slow, so be patient!</li>
+</ul>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,13 @@
+Uuid: 815bb4ab64e240618dc673d65016e919
+ExtensionType: 2
+Name: Get All Parameters
+RepoName: get-all-parameters
+ScreenVersion: 4.6
+SerialVersion: 1
+MinPlatformVersion: 2
+ProOnly: False
+Author: XNL-h4ck3r
+ShortDescription: Find potential endpoints, parameters, and generate a custom target wordlist.
+EntryPoint: GAP.py
+BuildCommand: 
+SupportedProducts: Pro, Community

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,9 +1,9 @@
 Uuid: 815bb4ab64e240618dc673d65016e919
 ExtensionType: 2
-Name: Get All Parameters
+Name: GAP (Get All Parameters, Links, and Words)
 RepoName: get-all-parameters
 ScreenVersion: 4.6
-SerialVersion: 1
+SerialVersion: 2
 MinPlatformVersion: 2
 ProOnly: False
 Author: XNL-h4ck3r


### PR DESCRIPTION
FIx a bug where files aren't written if more than one target is selected in Site Map. There was an error getting the Burp project name whcih wasn't caught correctly after Burp changes. It should get the project name successuflly now, but if it doesn't, the files will be written with prefix `UnknownProject_` instead of the project name.